### PR TITLE
Get rid of tabs / <all_urls> permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,6 @@
   },
   "permissions": [
     "storage",
-    "tabs",
-    "<all_urls>"
+    "activeTab"
   ]
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -168,10 +168,14 @@ addBtn.addEventListener("click", function(){
   /**
     Access the currently selected tab of chrome browser.
   */
-  chrome.tabs.getSelected(null, function(tab){
+  chrome.tabs.query({"active": true, "currentWindow": true}, function(tabs){
     /**
       Create list items and append them to the current list.
     */
+    if (!tabs.length) // Sanity check in case no active tab was found
+      return;
+    var tab = tabs[0];
+
     var newLink = {"title": tab.title, "timestamp": new Date().getTime()};
     if (newLink.title.length > 50)
       newLink.title = newLink.title.substr(0, 50) + "...";


### PR DESCRIPTION
activeTab permission is all the current code needs, removing all permission warnings: https://developer.chrome.com/extensions/activeTab

Also replaces deprecated `tabs.getSelected` call with `tabs.query`