### PR TITLE
Make changes apply immediately on sync update

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,16 @@
+chrome.runtime.onStartup.addListener(setBadge);
+chrome.runtime.onInstalled.addListener(setBadge);
+chrome.storage.onChanged.addListener(setBadge);
+
+function setBadge() {
+  chrome.storage.sync.get({count: 0}, function({count}) {
+    chrome.browserAction.setBadgeText({"text": badgeText(count)});
+  });
+}
+
+function badgeText(c) {
+	if(c > 999){
+		return c.toString()+"+";
+	}
+	return c.toString();
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,6 +7,10 @@
     "default_icon": "icon.png",
     "default_popup": "popup.html"
   },
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
   "permissions": [
     "storage",
     "activeTab"


### PR DESCRIPTION
Requires use of an event page. All badge manipulation shifted there.

Added bonus: the count appears immediately on extension load, no need to open popup to update.

Note: for testing, it may be useful to pin the ID (because of the `sync` storage involved).

I used the following manifest key to pin the id (randomly generated, results in consistent id `kjgkklfalnfcbenbefkoojgefaahpekh`):

    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0ykeOQKuF92dCcnbHA0yz5PMRzh3dJ5D3KvZbq/tS8faQdixcHEYyOqIm+zovvjcnT4nBaZrpOl0YfpfmwpaXu0Q0kWdJWd9D2XFZzJqluFv6goh9A5NljPo4lsVZOpG9x7Pki/lyJvU6GDIgcq15vTRRtIC7ioN/XzeximgQ88p5dMUVfDBy22iKAJdi8fIxq0PSvbz6AxH9oXjvSyPkVIgT4tCQ1x3Dy9PpmaTihMt/lW+en1lEz06emY2IzJC+PSeLnNd8SvEWEXGmS/U0YVatmiWSePgG/W0jda/M4DoMeRto3YNrnYtpQYt2xsbdssZqnJ63fSIhOnbLPEFFwIDAQAB"