### PR TITLE
Fix button count upper threshold display

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -23,13 +23,15 @@ LICENSE: GPL-2.0
   - Listen to changes in sync storage
 **/
 
+const MAX_BUTTON_ITEMS = 999;
+
 let readLater = (function(storageObject) {
 
   let storage = storageObject;
 
   let badgeText = function(c) {
-    if (c > 999) {
-      return c.toString() + '+';
+    if (c > MAX_BUTTON_ITEMS) {
+      return MAX_BUTTON_ITEMS.toString() + '+';
     }
     return c.toString();
   };

--- a/src/core.js
+++ b/src/core.js
@@ -31,7 +31,7 @@ let readLater = (function(storageObject) {
 
   let badgeText = function(c) {
     if (c > MAX_BUTTON_ITEMS) {
-      return MAX_BUTTON_ITEMS.toString() + '+';
+      return `${MAX_BUTTON_ITEMS}+`;
     }
     return c.toString();
   };


### PR DESCRIPTION
`badgeText` intends to show '999+' count when it exceeds 999, but shows the original count with '+' instead. For example, if the count is 1021, the extension button will show '1021+'.