### PR TITLE
Toggle mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
     "extends": ["eslint:recommended", "google"],
+    "env": {
+        'es6': true
+    }
 };

--- a/src/background.js
+++ b/src/background.js
@@ -12,17 +12,27 @@ LICENSE: GPL-2.0
 
 */
 
+const NOTIFICATION_AUTOHIDE_DELAY = 700;
+
 var readLaterObject = readLater(chrome.storage.sync);
 
-var readLaterApp = (function(){
+var readLaterApp = (function() {
+
+	function displayNotification(id, title, message) {
+		chrome.notifications.create(id, {
+			type: "basic",
+			title: title,
+			message: message,
+			iconUrl: "icon.png"
+		}, function(id) {
+			setTimeout(function() {
+				chrome.notifications.clear(id);
+			}, NOTIFICATION_AUTOHIDE_DELAY);
+		});
+	}
 
 	var remove_success = function(removedItem) {
-		chrome.notifications.create('RemovedFromBackground', {
-			type: "basic",
-			title: "Page Removed",
-			message: removedItem.title,
-			iconUrl: "icon.png"
-		});
+		displayNotification('RemovedFromBackground', "Page Removed", removedItem.title);		
 		console.log(`URL successfully removed.`);
 	};
 
@@ -33,12 +43,7 @@ var readLaterApp = (function(){
 	let removeUrlHandler = readLaterObject.removeURLHandler(remove_success, remove_failed)
 
 	var add_success = function(addedItem) {
-		chrome.notifications.create('AddedFromBackground', {
-			type: "basic",
-			title: "Page Added",
-			message: addedItem.data.title,
-			iconUrl: "icon.png"
-		});
+		displayNotification('AddedFromBackground', "Page Added", addedItem.data.title);		
 		console.log(`URL Item successfully added.`);
 	};
 

--- a/src/core.js
+++ b/src/core.js
@@ -114,11 +114,7 @@ let readLater = (function(storageObject) {
 
     toggleURLFromTabHandler: function(tabFound_callback) {
       return function() {
-        chrome.tabs.query({"active": true, 'currentWindow': true}, function(tabs) {
-          if (!tabs.length) // Sanity check in case no active tab was found
-            {return;}
-          let tab = tabs[0];
-
+        getCurrentTab().then(tab => {
           let urlItem = createURLItemFromTab(tab);
           tabFound_callback(urlItem);
         });

--- a/src/core.js
+++ b/src/core.js
@@ -158,8 +158,29 @@ let readLater = (function(storageObject) {
           storage.clear(success_callback);
         }
       };
-    },
+    }
+
   };
   
 });
 
+
+/**
+ * Returns a promise for the currently active tab in Chrome.
+ */
+function getCurrentTab() {
+
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({
+      active: true, 
+      currentWindow: true
+    }, tabs => {
+      if (tabs.length) {
+        resolve(tabs[0]);
+      } else {
+        reject();
+      }
+    });
+  });
+  
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,15 +16,16 @@
   },
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "notifications"
   ],
   "commands": {
-    "add-url": {
+    "toggle-url": {
       "suggested_key": {
         "default": "Ctrl+Shift+L",
         "mac": "Command+Shift+L"
       },
-      "description": "Add current page to ReadLater"
+      "description": "Add/remove current page"
     }
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -21,7 +21,7 @@ LICENSE: GPL-2.0
     <div id="header"><h1>ReadLater</h1><span>Save now, Read Later</span></div>
     <!--<div id="currentLink"></div>-->
     <div id="container">
-      <span id="addBtn">ADD</span>
+      <span id="toggleBtn">TOGGLE</span>
       <span id="clearBtn">CLEAR ALL</span>
       <div id="message">Total Links: </div>
     </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -16,6 +16,18 @@ Create variables for the DOM elements.
 */
 var readLaterObject = readLater(chrome.storage.sync);
 
+
+const TOKENS = {
+  addToList: {
+    text: "ADD",
+    title: "Add the currently opened URL to the list"
+  },
+  removeFromList: {
+    text: "REMOVE",
+    title: "Remove the currently opened URL from the list"
+  }
+};
+
 var readLaterApp = (function(readLaterObject){
   var toggleBtn = document.getElementById("toggleBtn");
   var clearBtn = document.getElementById("clearBtn");
@@ -46,13 +58,13 @@ var readLaterApp = (function(readLaterObject){
     return title;
   };
 
-  var show_total_links = readLaterObject.getCountsHandler(function(counts){
+  var showTotalLinks = readLaterObject.getCountsHandler(function(counts){
     msg.innerText = `Total Links: ${counts}`;
   });
 
   var message = function(messageStr) {
     msg.innerText = messageStr;
-    setTimeout(show_total_links, 1000);
+    setTimeout(showTotalLinks, 1000);
   };
 
   var add_success = function(){
@@ -62,7 +74,6 @@ var readLaterApp = (function(readLaterObject){
 
   var add_exists = function(urlItem){
     removeURL(urlItem.url);
-    message("URL removed.");
   };
 
   var remove_success = function(){
@@ -135,7 +146,7 @@ var readLaterApp = (function(readLaterObject){
       links.innerHTML = "";
       var counts = syncItems.length;
       //console.log(syncItems);
-      message(`Loaded ${counts} links.`);
+      showTotalLinks();
 
       syncItems.sort(function(a, b) {
         if (a.timestamp < b.timestamp) return -1;
@@ -161,13 +172,14 @@ var readLaterApp = (function(readLaterObject){
 
       });
 
-      // Update the caption of the toggle button according to whether the current tab
+      // Update the caption and title of the toggle button according to whether the current tab
       // is in the URL list.
       getCurrentTab().then(tab => {
-        toggleBtn.innerText = knownUrls[tab.url] ? "REMOVE" : "ADD";
+        let buttonTokens = knownUrls[tab.url] ? TOKENS.removeFromList : TOKENS.addToList;
+        toggleBtn.innerText = buttonTokens.text;
+        toggleBtn.title = buttonTokens.title;
       });
 
-      message("Finished!");
     });
 
   };

--- a/src/popup.js
+++ b/src/popup.js
@@ -47,7 +47,7 @@ var readLaterApp = (function(readLaterObject){
   };
 
   var show_total_links = readLaterObject.getCountsHandler(function(counts){
-    msg.innerText = `Total Links:${counts}`;
+    msg.innerText = `Total Links: ${counts}`;
   });
 
   var message = function(messageStr) {

--- a/src/popup.js
+++ b/src/popup.js
@@ -79,7 +79,7 @@ var readLaterApp = (function(readLaterObject){
     init();
   };
 
-  var addURL = readLaterObject.addURLHandler(add_success, add_exists);
+  var addURL = readLaterObject.toggleURLHandler(add_success, add_exists);
   var removeURL = readLaterObject.removeURLHandler(remove_success, remove_failed);
 
   var removeAction = function(e){
@@ -102,7 +102,7 @@ var readLaterApp = (function(readLaterObject){
   };
 
   var clearAll = readLaterObject.clearAllHandler(clear_all_success);
-  var addURLFromTab = readLaterObject.addURLFromTabHandler(addURL);
+  var addURLFromTab = readLaterObject.toggleURLFromTabHandler(addURL);
 
   addBtn.addEventListener("click", addURLFromTab);
   clearBtn.addEventListener("click", clearAll);

--- a/src/style.css
+++ b/src/style.css
@@ -73,14 +73,14 @@ body {
   float: left;
   width: 100%;
 }
-#addBtn{
+#toggleBtn {
   float: right;
   text-transform: uppercase;
   font-size: 12px;
   margin: 12px 6px;
   cursor: pointer;
 }
-#addBtn:hover, #clearBtn:hover {
+#toggleBtn:hover, #clearBtn:hover {
   color: #259DFF;
   text-decoration: underline;
 }


### PR DESCRIPTION
This pull request changes the logic of working with the current URL.

- The `add-url` command has been changed to `toggle-url` command, which now either adds or removes the current URL to/from the link list. This action will also be reported by a short Chrome notification (a `notifications` permission was added for that purpose).
- The 'ADD' button now displays as 'ADD' or 'REMOVE' depending on whether the current URL is present in the link list, and functions accordingly.

Also, some minor UI modifications were made:
- Space after colon was added for the "Total Links" label;
- Message display for "URL removed" and "Finished!" was removed, since it seems excess or even debuggish.